### PR TITLE
fix: 금리 조회시 gmgoCd 대신 banks가 사용되는 부분 수정

### DIFF
--- a/src/main_bank.ts
+++ b/src/main_bank.ts
@@ -27,7 +27,7 @@ async function main() {
 	const banks = JSON.parse(text) as BankDefinition[];
 	const ids = _.uniq(banks.map(x => x.gmgoCd));
 
-	// await stage_fetch(banks);
+	// await stage_fetch(ids);
 	await stage_parse(ids);
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7875341/210348849-4ff73ec0-3420-4aee-a79f-69f226df3537.png)
금리 조회시 gmgoCd 대신 banks가 사용되여 아래 사진과 같이 에러가 발생하여 수정하였습니다.

덕분에 잘 사용하였습니다. 감사합니다.
